### PR TITLE
Make copying content more forgiving to contents

### DIFF
--- a/resources/views/columns/copyable-text-column.blade.php
+++ b/resources/views/columns/copyable-text-column.blade.php
@@ -11,7 +11,7 @@
     {{ $getFormattedState() }}
     @if($getFormattedState())
         <button :class="open || clicked || !isShowOnHover ? 'opacity-100' : 'opacity-0'"
-            @click.prevent="$clipboard('{{$getFormattedState()}}');clicked = true;">
+            @click.prevent="$clipboard(new DOMParser().parseFromString(`{{ htmlspecialchars($getFormattedState(), ENT_QUOTES) }}`, 'text/html').documentElement.textContent);clicked = true;">
 
             <x-icon :name="$getIcon()" x-show="!clicked" class="w-5 h-5 "/>
             <x-heroicon-o-check x-show="clicked && open" class="w-5 h-5 text-success-500"


### PR DESCRIPTION
This will make it so contents with double quotes will not break by causing token errors.